### PR TITLE
Duplication support for clip generators

### DIFF
--- a/ERClipGeneratorTool/Util/DupeExtensions.cs
+++ b/ERClipGeneratorTool/Util/DupeExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace ERClipGeneratorTool.Util;
+
+public static class DupeExtensions
+{
+    public static List<int> GetTaeIdsFromString(string idsString)
+    {
+        List<string> taeIdStrings = idsString.Split(",").Select(i => i.Trim()).ToList();
+        if (taeIdStrings.Count == 0) taeIdStrings = new List<string> { idsString };
+        var taeIds = new List<int>();
+        foreach (string idString in taeIdStrings)
+        {
+            if (idString.Contains("-"))
+            {
+                int startTaeId = int.TryParse(idString.Split("-")[0], out int st) ? st : -1;
+                if (startTaeId == -1) return new List<int>();
+                int endTaeId = int.TryParse(idString.Split("-")[1], out int et) ? et : -1;
+                if (endTaeId == -1) return new List<int>();
+                for (int i = startTaeId; i <= endTaeId; ++i) taeIds.Add(i);
+            }
+            else
+            {
+                int id = int.TryParse(idString, out int i) ? i : -1;
+                if (id == -1) return new List<int>();
+                taeIds.Add(id);
+            }
+        }
+        return taeIds.Distinct().ToList();
+    }
+}

--- a/ERClipGeneratorTool/ViewModels/ClipGeneratorDupeViewModel.cs
+++ b/ERClipGeneratorTool/ViewModels/ClipGeneratorDupeViewModel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Reactive;
+using System.Reactive.Linq;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+
+namespace ERClipGeneratorTool.ViewModels;
+
+public class ClipGeneratorDupeViewModel : ViewModelBase
+{
+    public ClipGeneratorDupeViewModel()
+    {
+        IObservable<bool> isValid = this.WhenAnyValue(x => x.TaeIds).Select(x =>
+            ClipGeneratorViewModel.ValidateOffsets(x) == ValidationResult.Success);
+        ConfirmCommand = ReactiveCommand.Create(() => true, isValid);
+        CancelCommand = ReactiveCommand.Create(() => false);
+    }
+
+    [Reactive]
+    [CustomValidation(typeof(ClipGeneratorViewModel), nameof(ClipGeneratorViewModel.ValidateOffsets))]
+    public string TaeIds { get; set; } = "0";
+
+    public ReactiveCommand<Unit, bool> ConfirmCommand { get; }
+
+    public ReactiveCommand<Unit, bool> CancelCommand { get; }
+}

--- a/ERClipGeneratorTool/ViewModels/ClipGeneratorDupeViewModel.cs
+++ b/ERClipGeneratorTool/ViewModels/ClipGeneratorDupeViewModel.cs
@@ -12,13 +12,13 @@ public class ClipGeneratorDupeViewModel : ViewModelBase
     public ClipGeneratorDupeViewModel()
     {
         IObservable<bool> isValid = this.WhenAnyValue(x => x.TaeIds).Select(x =>
-            ClipGeneratorViewModel.ValidateOffsets(x) == ValidationResult.Success);
+            ClipGeneratorViewModel.ValidateTaeIds(x) == ValidationResult.Success);
         ConfirmCommand = ReactiveCommand.Create(() => true, isValid);
         CancelCommand = ReactiveCommand.Create(() => false);
     }
 
     [Reactive]
-    [CustomValidation(typeof(ClipGeneratorViewModel), nameof(ClipGeneratorViewModel.ValidateOffsets))]
+    [CustomValidation(typeof(ClipGeneratorViewModel), nameof(ClipGeneratorViewModel.ValidateTaeIds))]
     public string TaeIds { get; set; } = "0";
 
     public ReactiveCommand<Unit, bool> ConfirmCommand { get; }

--- a/ERClipGeneratorTool/ViewModels/ClipGeneratorViewModel.cs
+++ b/ERClipGeneratorTool/ViewModels/ClipGeneratorViewModel.cs
@@ -1,12 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Text.RegularExpressions;
+using ERClipGeneratorTool.Util;
 using HKLib.hk2018;
 using ReactiveHistory;
 using ReactiveUI;
-using ReactiveCommand = ReactiveUI.ReactiveCommand;
 
 // ReSharper disable BitwiseOperatorOnEnumWithoutFlags
 
@@ -24,13 +26,10 @@ public partial class ClipGeneratorViewModel : ViewModelBase, IActivatableViewMod
         _clipGenerator = clipGenerator;
         _history = history;
         _parents = parents;
-
         Activator = new ViewModelActivator();
-
         this.WhenActivated(d =>
         {
             DeleteCommand = ReactiveCommand.Create(Delete).DisposeWith(d);
-
             this.WhenAnyValue(x => x.Name)
                 .ObserveWithHistory(value => Name = value ?? "", clipGenerator.m_name, history);
             this.WhenAnyValue(x => x.AnimationName).ObserveWithHistory(value => AnimationName = value ?? "",
@@ -146,7 +145,7 @@ public partial class ClipGeneratorViewModel : ViewModelBase, IActivatableViewMod
         hkbClipGenerator.PlaybackMode.MODE_LOOPING,
         hkbClipGenerator.PlaybackMode.MODE_USER_CONTROLLED,
         hkbClipGenerator.PlaybackMode.MODE_PING_PONG,
-        hkbClipGenerator.PlaybackMode.MODE_COUNT,
+        hkbClipGenerator.PlaybackMode.MODE_COUNT
     };
 
     public hkbClipGenerator.ClipFlags Flags
@@ -237,7 +236,6 @@ public partial class ClipGeneratorViewModel : ViewModelBase, IActivatableViewMod
         {
             parent.m_generators.Remove(_clipGenerator);
         }
-
         _parents.Clear();
     }
 
@@ -248,6 +246,30 @@ public partial class ClipGeneratorViewModel : ViewModelBase, IActivatableViewMod
             cmsg.m_generators.Add(_clipGenerator);
             _parents.Add(cmsg);
         }
+    }
+
+    public hkbClipGenerator DuplicateInternal()
+    {
+        hkbClipGenerator copy = new()
+        {
+            m_propertyBag = new hkPropertyBag(),
+            m_variableBindingSet = _clipGenerator.m_variableBindingSet,
+            m_userData = _clipGenerator.m_userData,
+            m_name = _clipGenerator.m_name,
+            m_animationName = _clipGenerator.m_animationName,
+            m_triggers = _clipGenerator.m_triggers,
+            m_userPartitionMask = _clipGenerator.m_userPartitionMask,
+            m_cropStartAmountLocalTime = _clipGenerator.m_cropStartAmountLocalTime,
+            m_cropEndAmountLocalTime = _clipGenerator.m_cropEndAmountLocalTime,
+            m_startTime = _clipGenerator.m_startTime,
+            m_playbackSpeed = _clipGenerator.m_playbackSpeed,
+            m_enforcedDuration = _clipGenerator.m_enforcedDuration,
+            m_userControlledTimeFraction = _clipGenerator.m_userControlledTimeFraction,
+            m_mode = _clipGenerator.m_mode,
+            m_flags = _clipGenerator.m_flags,
+            m_animationInternalId = _clipGenerator.m_animationInternalId
+        };
+        return copy;
     }
 
     public ClipGeneratorViewModel Duplicate()
@@ -271,7 +293,6 @@ public partial class ClipGeneratorViewModel : ViewModelBase, IActivatableViewMod
             m_flags = _clipGenerator.m_flags,
             m_animationInternalId = _clipGenerator.m_animationInternalId
         };
-
         return new ClipGeneratorViewModel(copy, new List<CustomManualSelectorGenerator>(), _history);
     }
 
@@ -283,9 +304,17 @@ public partial class ClipGeneratorViewModel : ViewModelBase, IActivatableViewMod
         {
             return ValidationResult.Success;
         }
-
         return new ValidationResult(
             "Invalid animation name format. The animation name must correspond to a valid TAE Id.");
+    }
+
+    public static ValidationResult? ValidateOffsets(string? offsetsString)
+    {
+        if (offsetsString is null) return new ValidationResult("At least one offset value must be specified.");
+        bool isValid = DupeExtensions.GetTaeIdsFromString(offsetsString).Count > 0;
+        if (isValid) return ValidationResult.Success;
+        return new ValidationResult(
+            "Invalid offset values. All offsets specified must be positive integer values.");
     }
 
     [GeneratedRegex("^a[0-9]{3}_[0-9]{6}$")]

--- a/ERClipGeneratorTool/ViewModels/ClipGeneratorViewModel.cs
+++ b/ERClipGeneratorTool/ViewModels/ClipGeneratorViewModel.cs
@@ -308,13 +308,13 @@ public partial class ClipGeneratorViewModel : ViewModelBase, IActivatableViewMod
             "Invalid animation name format. The animation name must correspond to a valid TAE Id.");
     }
 
-    public static ValidationResult? ValidateOffsets(string? offsetsString)
+    public static ValidationResult? ValidateTaeIds(string? taeIdsString)
     {
-        if (offsetsString is null) return new ValidationResult("At least one offset value must be specified.");
-        bool isValid = DupeExtensions.GetTaeIdsFromString(offsetsString).Count > 0;
+        if (taeIdsString is null) return new ValidationResult("At least one TAE ID must be specified.");
+        bool isValid = DupeExtensions.GetTaeIdsFromString(taeIdsString).Count > 0;
         if (isValid) return ValidationResult.Success;
         return new ValidationResult(
-            "Invalid offset values. All offsets specified must be positive integer values.");
+            "Invalid TAE ID values. All TAE IDs must be positive integer values.");
     }
 
     [GeneratedRegex("^a[0-9]{3}_[0-9]{6}$")]

--- a/ERClipGeneratorTool/Views/BehaviorGraphView.axaml
+++ b/ERClipGeneratorTool/Views/BehaviorGraphView.axaml
@@ -18,7 +18,14 @@
                      SelectedItem="{Binding CurrentClipGenerator}"
                      AutoScrollToSelectedItem="True"
                      Grid.Row="1"
-                     VerticalAlignment="Stretch">
+                     VerticalAlignment="Stretch"
+                     SelectionMode="Multiple"
+                     SelectedItems="{Binding SelectedClipGenerators}">
+                <ListBox.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Command="{Binding DuplicateAsync}" Header="Duplicate To"></MenuItem>
+                    </ContextMenu>
+                </ListBox.ContextMenu>
                 <ListBox.DataTemplates>
                     <DataTemplate DataType="viewModels:ClipGeneratorViewModel">
                         <TextBlock Text="{Binding Name}" />

--- a/ERClipGeneratorTool/Views/BehaviorGraphView.axaml.cs
+++ b/ERClipGeneratorTool/Views/BehaviorGraphView.axaml.cs
@@ -22,12 +22,23 @@ public partial class BehaviorGraphView : ReactiveUserControl<BehaviorGraphViewMo
         {
             ViewModel!.ShowMessageBox.RegisterHandler(ShowMessageBoxAsync).DisposeWith(d);
             ViewModel!.GetClipGeneratorOptions.RegisterHandler(GetClipGeneratorOptionsAsync).DisposeWith(d);
+            ViewModel!.GetClipGeneratorDupeOptions.RegisterHandler(GetClipGeneratorDupeOptionsAsync).DisposeWith(d);
         });
     }
 
     private async Task GetClipGeneratorOptionsAsync(InteractionContext<ClipGeneratorOptionsViewModel, bool> interaction)
     {
         ClipGeneratorOptionsView view = new()
+        {
+            DataContext = interaction.Input
+        };
+
+        interaction.SetOutput(await view.ShowDialog<bool>(this.FindAncestorOfType<Window>()!));
+    }
+
+    private async Task GetClipGeneratorDupeOptionsAsync(InteractionContext<ClipGeneratorDupeViewModel, bool> interaction)
+    {
+        ClipGeneratorDupeView view = new()
         {
             DataContext = interaction.Input
         };

--- a/ERClipGeneratorTool/Views/ClipGeneratorDupeView.axaml
+++ b/ERClipGeneratorTool/Views/ClipGeneratorDupeView.axaml
@@ -1,0 +1,33 @@
+<reactiveUi:ReactiveWindow x:TypeArguments="viewModels:ClipGeneratorDupeViewModel"
+                           xmlns="https://github.com/avaloniaui"
+                           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                           xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                           xmlns:viewModels="clr-namespace:ERClipGeneratorTool.ViewModels"
+                           xmlns:reactiveUi="http://reactiveui.net"
+                           mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+                           x:Class="ERClipGeneratorTool.Views.ClipGeneratorDupeView"
+                           WindowStartupLocation="CenterOwner"
+                           MaxHeight="100"
+                           MaxWidth="300"
+                           MinHeight="100"
+                           MinWidth="300">
+    <!-- ExtendClientAreaToDecorationsHint="True" -->
+    <!-- ExtendClientAreaChromeHints="PreferSystemChrome" -->
+    <!-- ExtendClientAreaTitleBarHeightHint="-1" -->
+
+    <Design.DataContext>
+        <viewModels:ClipGeneratorDupeViewModel />
+    </Design.DataContext>
+
+    <Grid RowDefinitions="40, 40" Margin="5">
+        <Grid ColumnDefinitions="*, *" Grid.RowDefinitions="30, 25" Grid.Row="0" Margin="5">
+            <TextBlock IsHitTestVisible="False" Text="TAE IDs:" VerticalAlignment="Center" Grid.Column="0" />
+            <TextBox Text="{Binding TaeIds}" VerticalContentAlignment="Center" Grid.Row="0" Grid.Column="1" />
+        </Grid>
+        <Grid ColumnDefinitions="*, *" Grid.Row="1" Margin="5">
+            <Button Content="Cancel" Command="{Binding CancelCommand}" HotKey="Escape" Margin="0, 0, 2, 0" Grid.Column="0" />
+            <Button Content="Ok" Command="{Binding ConfirmCommand}" HotKey="Enter" Margin="2, 0, 0, 0" Grid.Column="1" />
+        </Grid>
+    </Grid>
+</reactiveUi:ReactiveWindow>

--- a/ERClipGeneratorTool/Views/ClipGeneratorDupeView.axaml.cs
+++ b/ERClipGeneratorTool/Views/ClipGeneratorDupeView.axaml.cs
@@ -1,0 +1,29 @@
+using System;
+using Avalonia;
+using Avalonia.Markup.Xaml;
+using Avalonia.ReactiveUI;
+using ERClipGeneratorTool.ViewModels;
+using ReactiveUI;
+
+namespace ERClipGeneratorTool.Views;
+
+public partial class ClipGeneratorDupeView : ReactiveWindow<ClipGeneratorDupeViewModel>
+{
+    public ClipGeneratorDupeView()
+    {
+        InitializeComponent();
+        this.WhenActivated(d =>
+        {
+            d(ViewModel!.ConfirmCommand.Subscribe(x => Close(x)));
+            d(ViewModel!.CancelCommand.Subscribe(x => Close(x)));
+        });
+#if DEBUG
+        this.AttachDevTools();
+#endif
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
Clip generators can now be properly duplicated by selecting one or more clip generators in the left-hand view, performing a right-click, and then selecting "Duplicate To". In the dialog that appears, you can enter one or more individual TAE IDs separated by `,` characters, or even specify ranges of TAE ID values using `-` characters. Range expressions and individual ID values can be used in tandem with each other, to allow for more control. Any existing clip generators which match a given TAE ID(s), either explicitly, or implicitly through range expressions, will not be overwritten.