### PR TITLE
Slight improvements to UI

### DIFF
--- a/ERClipGeneratorTool/ERClipGeneratorTool.csproj
+++ b/ERClipGeneratorTool/ERClipGeneratorTool.csproj
@@ -10,9 +10,9 @@
         <ApplicationIcon>Assets\hbt.ico</ApplicationIcon>
     </PropertyGroup>
     <ItemGroup>
-        <Folder Include="Models\"/>
-        <AvaloniaResource Include="Assets\**"/>
-        <None Remove=".gitignore"/>
+        <Folder Include="Models\" />
+        <AvaloniaResource Include="Assets\**" />
+        <None Remove=".gitignore" />
         <None Update="Settings.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
@@ -21,25 +21,25 @@
         <!--This helps with theme dll-s trimming.
         If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
         https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
-        <TrimmableAssembly Include="Avalonia.Themes.Fluent"/>
-        <TrimmableAssembly Include="Avalonia.Themes.Default"/>
+        <TrimmableAssembly Include="Avalonia.Themes.Fluent" />
+        <TrimmableAssembly Include="Avalonia.Themes.Default" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.0-preview5"/>
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview5"/>
+        <PackageReference Include="Avalonia" Version="11.0.0-preview5" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview5" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview5" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview5"/>
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview5"/>
-        <PackageReference Include="MessageBox.Avalonia" Version="2.3.1-prev5"/>
-        <PackageReference Include="ReactiveHistory" Version="0.10.7"/>
-        <PackageReference Include="ReactiveProperty" Version="9.0.0"/>
-        <PackageReference Include="ReactiveUI.Fody" Version="18.4.26"/>
-        <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0"/>
-        <PackageReference Include="XamlNameReferenceGenerator" Version="1.6.1"/>
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview5" />
+        <PackageReference Include="MessageBox.Avalonia" Version="2.3.1-prev5" />
+        <PackageReference Include="ReactiveHistory" Version="0.10.7" />
+        <PackageReference Include="ReactiveProperty" Version="9.0.0" />
+        <PackageReference Include="ReactiveUI.Fody" Version="18.4.26" />
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+        <PackageReference Include="XamlNameReferenceGenerator" Version="1.6.1" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\HKLib\HKLib.Serialization\HKLib.Serialization.csproj"/>
-        <ProjectReference Include="..\SoulsFormats\SoulsFormats\SoulsFormats.csproj"/>
+        <ProjectReference Include="..\HKLib\HKLib.Serialization\HKLib.Serialization.csproj" />
+        <ProjectReference Include="..\SoulsFormats\SoulsFormats\SoulsFormats.csproj" />
     </ItemGroup>
     <ItemGroup>
         <Reference Include="Avalonia.Themes.Simple">

--- a/ERClipGeneratorTool/Views/BehaviorGraphView.axaml
+++ b/ERClipGeneratorTool/Views/BehaviorGraphView.axaml
@@ -14,7 +14,8 @@
     <Grid Margin="10" ColumnDefinitions="*, *">
         <Grid RowDefinitions="40, *, 40" Grid.Column="0">
             <TextBox Text="{Binding Filter}" Watermark="Search..." Margin="0, 5" Grid.Row="0" />
-            <ListBox Items="{Binding FilteredGenerators}"
+            <ListBox Name="clipGeneratorsListBox"
+                     Items="{Binding FilteredGenerators}"
                      AutoScrollToSelectedItem="True"
                      VerticalAlignment="Stretch"
                      SelectionMode="Multiple"

--- a/ERClipGeneratorTool/Views/MainWindow.axaml
+++ b/ERClipGeneratorTool/Views/MainWindow.axaml
@@ -9,8 +9,8 @@
                      x:TypeArguments="vm:MainWindowViewModel"
                      Title="ERClipGeneratorTool"
                      CanResize="True"
-                     MinWidth="400"
-                     MinHeight="100"
+                     MinWidth="500"
+                     MinHeight="500"
                      Width="900"
                      Height="600"
                      WindowStartupLocation="CenterScreen"
@@ -24,6 +24,9 @@
     </Design.DataContext>
 
     <Window.Styles>
+        <Style Selector="Window[WindowState=Maximized]">
+            <Setter Property="Padding" Value="8" />
+        </Style>
         <Style Selector="Menu > MenuItem">
             <Setter Property="VerticalAlignment" Value="Stretch" />
             <Setter Property="Width" Value="50" />


### PR DESCRIPTION
-Window minimum size has now been increased to (500, 500), to improve usability and readability since there is no need for an absurd amount of minimization
-Previously, when the window was maximized, it would extend just beyond the borders of the display, causing a cosmetically displeasing effect. Windows, as an operating system and by default, applies an 8-pixel border to the edges of its internally created window frames, and Avalonia UI does not deal with this automatically. This pull request fixes this issue by applying the padding value manually